### PR TITLE
Fix README path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip install -r requirements.txt
 
 ## Configuration
 
-The application requires configuration to connect to your Nextcloud instance. Look at the config.example.yaml file in the /src/mcp, /src/api and /src/nexcloud directories. Rename them in config.yaml and edit them according to your needs.
+The application requires configuration to connect to your Nextcloud instance. Look at the config.example.yaml file in the /src/mcp, /src/api and /src/nextcloud directories. Rename them in config.yaml and edit them according to your needs.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- correct the README configuration instructions to point to `/src/nextcloud` instead of the misspelled `/src/nexcloud`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ac209d5c832e94a31397fd64fe88