### PR TITLE
Remove MCP-specific dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,16 +9,13 @@ certifi==2025.4.26
 charset-normalizer==3.4.2
 click==8.1.8
 fastapi==0.115.12
-fastapi-mcp==0.3.3
 frozenlist==1.6.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
-httpx-sse==0.4.0
 icalendar==6.1.3
 idna==3.10
 markdown-it-py==3.0.0
-mcp==1.7.1
 mdurl==0.1.2
 multidict==6.4.3
 propcache==0.3.1
@@ -35,7 +32,6 @@ rich==14.0.0
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
-sse-starlette==2.3.3
 starlette==0.46.2
 tomli==2.2.1
 typer==0.15.3


### PR DESCRIPTION
## Summary
- remove the MCP server-only packages from the Python requirements list now that the server implementation is gone

## Testing
- ✅ `pip install -r requirements.txt`
- ❌ `pytest tests/ -v` *(fails: FileNotFoundError: /workspace/api-sabre-nx-2/src/nextcloud/config.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b2805250832ebc5827a7fd293efc